### PR TITLE
Check cakeWamp.options before checking properties

### DIFF
--- a/webroot/js/cake-wamp.js
+++ b/webroot/js/cake-wamp.js
@@ -29,12 +29,12 @@ cakeWamp.onhangupListeners = [];
  */
 cakeWamp.connect = function() {
 
-    if (cakeWamp.options.debugWamp) {
+    if (cakeWamp.options && cakeWamp.options.debugWamp) {
         ab._debugrpc = true;
         ab._debugpubsub = true;
     }
 
-    if (cakeWamp.options.debugWs) {
+    if (cakeWamp.options && cakeWamp.options.debugWs) {
         ab._debugws = true;
     }
 


### PR DESCRIPTION
Without this check, and without options defined JavaScript errors occur.

It looks like the GitHub editor removed a line break character on line 116 as well.
