### PR TITLE
Added helper

### DIFF
--- a/docs/helper.md
+++ b/docs/helper.md
@@ -5,14 +5,14 @@ The `Ratchet` plugin contains a helper that sets all the client side details for
 
 ```php
 $helpers = [
-  'Ratchet.Wamp',
+  'WyriHaximus/Ratchet.Wamp',
 ];
 ```
 
-Then in your view or layout template add this:
+The helper will automatically append the required JavaScript to the `script` block. If you're not fetching the script block in your view, you can do so by adding the following:
 
 ```php
-<?php $this->Wamp->init(); ?>
+<?= $this->fetch('script') ?>
 ```
 
 That will generate the needed code to configure and setup the websocket clientside tools.

--- a/src/Template/Element/wamp.ctp
+++ b/src/Template/Element/wamp.ctp
@@ -1,0 +1,24 @@
+<?php
+use Cake\Core\Configure;
+?>
+<script>
+    WEB_SOCKET_SWF_LOCATION = "<?= $this->Url->build('WyriHaximus/Ratchet/swf/WebSocketMain.swf', true) ?>";
+	var cakeWamp = window.cakeWamp || {};
+	cakeWamp.options = {
+    <?php if (Configure::read('debug') == 2): ?>
+        debugWamp: true,
+    <?php endif; ?>
+        retryDelay: "<?= (int)Configure::read('WyriHaximus.Ratchet.Client.retryDelay') ?>",
+        maxRetries: "<?= (int)Configure::read('WyriHaximus.Ratchet.Client.maxRetries') ?>"
+    };
+    <?php
+    $uri = (Configure::read('WyriHaximus.Ratchet.Connection.Websocket.secure') ? 'wss' : 'ws') . '://';
+    $uri .= Configure::read('WyriHaximus.Ratchet.Connection.Websocket.address');
+    $uri .= ':' . Configure::read('WyriHaximus.Ratchet.Connection.Websocket.port');
+    ?>
+    wsuri = "<?= $uri; ?>";
+    <?php if (Configure::read('WyriHaximus.Ratchet.Connection.keepaliveInterval') > 0): ?>
+    cakeWamp.subscribe('WyriHaximus.Ratchet.Connection.keepAlive', function (topic, event) {});
+    <?php endif; ?>
+</script>
+<?= $this->Html->script('WyriHaximus/Ratchet.ratchet.min.js') ?>

--- a/src/View/Helper/WampHelper.php
+++ b/src/View/Helper/WampHelper.php
@@ -1,0 +1,14 @@
+<?php
+namespace WyriHaximus\Ratchet\View\Helper;
+
+use Cake\View\Helper;
+
+class WampHelper extends Helper
+{
+
+    public function beforeLayout()
+    {
+        $this->_View->append('script', $this->_View->element('WyriHaximus\Ratchet.wamp'));
+    }
+
+}


### PR DESCRIPTION
I threw together the helper to output in the (usually already existing) script block. This allows us to just add the helper and not worry about the layout. If you'd like the plugin to require calling an "init" function like the 2.x version did, I can rework it.